### PR TITLE
Remove full paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.3",
   "description": "A React browserify boilerplate. Test your component quickly and continuously with Karma.",
   "scripts": {
-    "start": "./node_modules/browserify/bin/cmd.js ./assets/client.js -t reactify -o ./public/client.js",
-    "test": "./node_modules/karma/bin/karma start karma.conf.js",
-    "test:watch": "./node_modules/karma/bin/karma start karma.conf.js --no-single-run"
+    "start": "browserify ./assets/client.js -t reactify -o ./public/client.js",
+    "test": "karma start karma.conf.js",
+    "test:watch": "karma start karma.conf.js --no-single-run"
   },
   "keywords": [
     "facebook",


### PR DESCRIPTION
Thank you for this example, it's exactly what I was looking for! Just a minor adjustment, a really nice (and seemingly not well-known) thing about npm is that you don't need to put the full path to a binary within "scripts". And yes, this will work even if you do not install with the -g flag.
